### PR TITLE
Fix modals popping up when swiping on mobile device. Only a tap opens an info-modal

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -684,11 +684,11 @@ function setupGymMarker (item) {
       marker.persist = null
     })
 
-    marker.addListener('mouseover', function () {
+   /* marker.addListener('mouseover', function () {
       marker.infoWindow.open(map, marker)
       clearSelection()
       updateLabelDiffTime()
-    })
+    })*/
 
     marker.addListener('mouseout', function () {
       if (!marker.persist) {
@@ -878,11 +878,11 @@ function addListeners (marker) {
     marker.persist = null
   })
 
-  marker.addListener('mouseover', function () {
+  /*marker.addListener('mouseover', function () {
     marker.infoWindow.open(map, marker)
     clearSelection()
     updateLabelDiffTime()
-  })
+  })*/
 
   marker.addListener('mouseout', function () {
     if (!marker.persist) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -684,12 +684,14 @@ function setupGymMarker (item) {
       marker.persist = null
     })
 
-   /* marker.addListener('mouseover', function () {
-      marker.infoWindow.open(map, marker)
-      clearSelection()
-      updateLabelDiffTime()
-    })*/
-
+    if ( ! isTouchDevice() && ! isMobileDevice()) {
+      marker.addListener('mouseover', function () {
+        marker.infoWindow.open(map, marker)
+        clearSelection()
+        updateLabelDiffTime()
+      })
+    }
+    
     marker.addListener('mouseout', function () {
       if (!marker.persist) {
         marker.infoWindow.close()
@@ -877,13 +879,14 @@ function addListeners (marker) {
   google.maps.event.addListener(marker.infoWindow, 'closeclick', function () {
     marker.persist = null
   })
-
-  /*marker.addListener('mouseover', function () {
-    marker.infoWindow.open(map, marker)
-    clearSelection()
-    updateLabelDiffTime()
-  })*/
-
+  
+  if ( ! isTouchDevice() && ! isMobileDevice()) {
+    marker.addListener('mouseover', function () {
+      marker.infoWindow.open(map, marker)
+      clearSelection()
+      updateLabelDiffTime()
+    })
+  }
   marker.addListener('mouseout', function () {
     if (!marker.persist) {
       marker.infoWindow.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
See title

## Description
<!--- Describe your changes in detail -->
See title

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Because when having the map open on mobile (which 90% of the actual USERS) have, when zooming or moving map (swipe), Pokemon info screens popup. It's very annoying if you have a dense map. This easy fix solves it, and makes sure an info screen is only opened when you actually tap on it.


<!--- If it fixes an open issue, please link to the issue here. -->
No open issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested it on my map, on chrome, Samsung Internet app, and as home-screen-app (Galaxy S7 android)
Tested it on my map, on Chrome and Safari, and home-screen app (iPhone 6s iOS) 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
