### PR TITLE
Stop annoying popup windows on swipe/move

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -683,13 +683,16 @@ function setupGymMarker (item) {
     google.maps.event.addListener(marker.infoWindow, 'closeclick', function () {
       marker.persist = null
     })
-
+	
+	if ( ! isTouchDevice() && ! isMobileDevice()) {
     marker.addListener('mouseover', function () {
       marker.infoWindow.open(map, marker)
       clearSelection()
       updateLabelDiffTime()
     })
-
+	}
+	
+	
     marker.addListener('mouseout', function () {
       if (!marker.persist) {
         marker.infoWindow.close()
@@ -878,12 +881,14 @@ function addListeners (marker) {
     marker.persist = null
   })
 
+  if ( ! isTouchDevice() && ! isMobileDevice()) {
   marker.addListener('mouseover', function () {
     marker.infoWindow.open(map, marker)
     clearSelection()
     updateLabelDiffTime()
   })
-
+  }
+  
   marker.addListener('mouseout', function () {
     if (!marker.persist) {
       marker.infoWindow.close()


### PR DESCRIPTION
**Provide a general summary of your changes in the Title above**
On mobile devices, especially on larger/denser maps, zooming or swiping often results in multiple info-modals. I think this is annoying. 
If you want information about a pokemon,gym or pokestop you should be able to open info modal by just tapping it. 

**Description**
Modified map.js
Placed  mouseover eventlistener if-statement

` 
if ( ! isTouchDevice() && ! isMobileDevice()) {
 marker.addListener('mouseover', function () {
    marker.infoWindow.open(map, marker)
    clearSelection()
    updateLabelDiffTime()
  })
  }
`

Could easily be reversed by removing the if statement in case you absolutely need the annoying popups on swipe so hard.

**Motivation and Context**
_Why is this change required? What problem does it solve?_
It's not required, but solves a lot of irritation and phone trhow-aways, indirectly makes traffic safer too 👍 

**How Has This Been Tested?**
'implemented' it in my map and tested it on iPhone6 (chrome,safari), Galaxy S7 (chrome, samsung stock browser). All working fine. Also on desktop it works fine.


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
